### PR TITLE
pretty-checkbox의 CSS 적용 사항을 라이브러리에 포함

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
   "lib": {
-    "entryFile": "./src/public_api.ts"
+    "entryFile": "./src/public_api.ts",
+    "sassIncludePaths": ["./node_modules/pretty-checkbox/dist/pretty-checkbox.min.css"]
   },
-  "whitelistedNonPeerDependencies": ["."],
   "dest": "./lib-dist"
 }


### PR DESCRIPTION
이를 통해 해당 라이브러리를 사용할 때 이제 pretty-checkbox를 별도로 설치 및 적용하는 과정을 수행하지 않아도 됨